### PR TITLE
Fix log path portability and credential key collisions

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,10 @@
 ﻿// 总入口
+var logPath = Path.Combine(AppContext.BaseDirectory, "server_log.txt");
+
 GameManager.Instance.Initialize();
 MsgPoolManager.Instance.Initialize();
 NetworkManager.Instance.Initialize();
-LogManager.Instance.Initialize("E:\\GitProjects\\ERIUnitySimpleServer\\server_log.txt");
+LogManager.Instance.Initialize(logPath);
 
 NetworkManager.Instance.TcpStart();
 

--- a/Runtime/GameManager.cs
+++ b/Runtime/GameManager.cs
@@ -57,12 +57,18 @@ public class GameManager : AManager<GameManager>
     /// <returns>玩家对象</returns>
     public GamerInfo GetOrCreateGamer(string account, string password)
     {
-        if (_gamerInfoByAccountPassword.TryGetValue(account + password, out var gamer)) return gamer;
+        var credentialKey = BuildCredentialKey(account, password);
+        if (_gamerInfoByAccountPassword.TryGetValue(credentialKey, out var gamer)) return gamer;
         gamer = new GamerInfo(){ Account = account, Password = password };
         gamer.LogicData.ID = GameSetting.DefaultPlayerIdBase + (uint)_gamerInfoDic.Count + 1;
         _gamerInfoDic[gamer.LogicData.ID] = gamer;
-        _gamerInfoByAccountPassword[account + password] = gamer;
+        _gamerInfoByAccountPassword[credentialKey] = gamer;
         return gamer;
+    }
+
+    private static string BuildCredentialKey(string account, string password)
+    {
+        return $"{account}\u001F{password}";
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation

- Make the server startup more portable by removing a hard-coded Windows log file path and deriving a runtime-safe path instead. 
- Prevent credential dictionary key collisions caused by naive string concatenation of account and password.

### Description

- Replaced the hard-coded log file path in `Program.cs` with a portable path computed via `Path.Combine(AppContext.BaseDirectory, "server_log.txt")` and passed that to `LogManager.Initialize`.
- Reworked `GameManager.GetOrCreateGamer` to build a stable credential key via a new helper `BuildCredentialKey(string account, string password)` instead of using `account + password`, and updated dictionary lookups/assignments to use the new key.
- Added the `BuildCredentialKey` helper which uses an unambiguous separator (`\u001F`) to avoid accidental collisions.

### Testing

- Attempted to run `dotnet build TestKCPServer.sln -v minimal`, but the environment does not have `dotnet` installed so compilation could not be performed (command failed with `dotnet: command not found`).
- Verified the code changes and that the old hard-coded path and naive `account + password` pattern are no longer present by running `rg`/diff checks against the modified files, which succeeded.
- Committed the changes to the repository (`Fix portable log path and credential key collisions`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb2474e00833097434a8bd86cc9bb)