### PR TITLE
Harden login credential handling and remove plaintext password logging

### DIFF
--- a/Runtime/GameManager.cs
+++ b/Runtime/GameManager.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 /// <summary>
 /// 游戏管理器
 /// </summary>
@@ -13,9 +15,9 @@ public class GameManager : AManager<GameManager>
     /// </summary>
     private Dictionary<int, GamerInfo> _gamerInfoByPosDic;
     /// <summary>
-    /// 所有玩家信息的字典 key:玩家账号密码
+    /// 所有玩家信息的字典 key:玩家账号
     /// </summary>
-    private Dictionary<string, GamerInfo> _gamerInfoByAccountPassword;
+    private Dictionary<string, GamerInfo> _gamerInfoByAccount;
     /// <summary>
     /// 所有玩家信息的字典 key:玩家KCP连接ID
     /// </summary>
@@ -32,7 +34,7 @@ public class GameManager : AManager<GameManager>
     {
         _gamerInfoDic = new Dictionary<uint, GamerInfo>();
         _gamerInfoByPosDic = new Dictionary<int, GamerInfo>();
-        _gamerInfoByAccountPassword = new Dictionary<string, GamerInfo>();
+        _gamerInfoByAccount = new Dictionary<string, GamerInfo>();
         _gamerInfoByConnectionId = new Dictionary<int, GamerInfo>();
         _roomInfoDic = new Dictionary<uint, RoomInfo>();
     }
@@ -44,7 +46,7 @@ public class GameManager : AManager<GameManager>
     {
         _gamerInfoDic.Clear();
         _gamerInfoByPosDic.Clear();
-        _gamerInfoByAccountPassword.Clear();
+        _gamerInfoByAccount.Clear();
         _gamerInfoByConnectionId.Clear();
         _roomInfoDic.Clear();
     }
@@ -55,20 +57,39 @@ public class GameManager : AManager<GameManager>
     /// <param name="account">账号</param>
     /// <param name="password">密码</param>
     /// <returns>玩家对象</returns>
-    public GamerInfo GetOrCreateGamer(string account, string password)
+    public bool TryLoginOrCreateGamer(string account, string password, out GamerInfo gamer)
     {
-        var credentialKey = BuildCredentialKey(account, password);
-        if (_gamerInfoByAccountPassword.TryGetValue(credentialKey, out var gamer)) return gamer;
-        gamer = new GamerInfo(){ Account = account, Password = password };
+        gamer = null;
+        if (string.IsNullOrWhiteSpace(account) || string.IsNullOrEmpty(password)) return false;
+
+        if (_gamerInfoByAccount.TryGetValue(account, out gamer))
+        {
+            return VerifyPassword(gamer.PasswordHash, gamer.PasswordSalt, password);
+        }
+
+        var salt = new byte[16];
+        RandomNumberGenerator.Fill(salt);
+        gamer = new GamerInfo() { Account = account, PasswordSalt = salt, PasswordHash = HashPassword(salt, password) };
         gamer.LogicData.ID = GameSetting.DefaultPlayerIdBase + (uint)_gamerInfoDic.Count + 1;
         _gamerInfoDic[gamer.LogicData.ID] = gamer;
-        _gamerInfoByAccountPassword[credentialKey] = gamer;
-        return gamer;
+        _gamerInfoByAccount[account] = gamer;
+        return true;
     }
 
-    private static string BuildCredentialKey(string account, string password)
+    private static byte[] HashPassword(byte[] salt, string password)
     {
-        return $"{account}\u001F{password}";
+        var passwordBytes = System.Text.Encoding.UTF8.GetBytes(password);
+        var allBytes = new byte[salt.Length + passwordBytes.Length];
+        Buffer.BlockCopy(salt, 0, allBytes, 0, salt.Length);
+        Buffer.BlockCopy(passwordBytes, 0, allBytes, salt.Length, passwordBytes.Length);
+        return SHA256.HashData(allBytes);
+    }
+
+    private static bool VerifyPassword(byte[] expectedHash, byte[] salt, string password)
+    {
+        if (expectedHash == null || salt == null) return false;
+        var actualHash = HashPassword(salt, password);
+        return CryptographicOperations.FixedTimeEquals(expectedHash, actualHash);
     }
 
     /// <summary>

--- a/Runtime/GamerInfo.cs
+++ b/Runtime/GamerInfo.cs
@@ -28,7 +28,9 @@ public class GamerInfo
 {
     public string Account;
     
-    public string Password;
+    public byte[] PasswordHash;
+    
+    public byte[] PasswordSalt;
     
     public LogicData LogicData;
     

--- a/Runtime/NetworkManager.cs
+++ b/Runtime/NetworkManager.cs
@@ -332,8 +332,14 @@ public class NetworkManager : AManager<NetworkManager>
                 case (byte)pb.LogicMsgID.LogicMsgLogin:
                 {
                     var c2SMessage = pb.C2S_LoginMsg.Parser.ParseFrom(_memoryStream);
-                    LogManager.Instance.Log(LogType.Info, $"LogicMsgLogin -> account:{c2SMessage.Account.ToStringUtf8()} password:{c2SMessage.Password.ToStringUtf8()}");
-                    var gamer = gameManager.GetOrCreateGamer(c2SMessage.Account.ToStringUtf8(), c2SMessage.Password.ToStringUtf8());
+                    var account = c2SMessage.Account.ToStringUtf8();
+                    var password = c2SMessage.Password.ToStringUtf8();
+                    LogManager.Instance.Log(LogType.Info, $"LogicMsgLogin -> account:{account}");
+                    if (!gameManager.TryLoginOrCreateGamer(account, password, out var gamer))
+                    {
+                        SendLogicLoginMessage(stream, pb.LogicErrorCode.LogicErrAccount, 0);
+                        break;
+                    }
                     gamer.LogicData.NetworkStream = stream;
                     SendLogicLoginMessage(stream, pb.LogicErrorCode.LogicErrOk, gamer.LogicData.ID);
                     break;


### PR DESCRIPTION
### Motivation

- Fix a credential storage and logging vulnerability where plaintext passwords were stored and logged, exposing sensitive data in memory and logs.
- Replace the fragile "account+password" dictionary key approach with per-account lookup and verified authentication to prevent accidental account creation on invalid credentials.
- Reduce timing side‑channel risk during password checks by using a fixed-time comparison for hashes.

### Description

- Replace plaintext password storage on `GamerInfo` with `PasswordHash` and `PasswordSalt` byte arrays in `Runtime/GamerInfo.cs`.
- Add cryptographic utilities to `Runtime/GameManager.cs` (import `System.Security.Cryptography`) and replace `GetOrCreateGamer` with `TryLoginOrCreateGamer(string account, string password, out GamerInfo gamer)`, which returns `true` only when login succeeds or a new account is created successfully.
- Generate a 16‑byte salt with `RandomNumberGenerator.Fill`, compute the password hash with `SHA256.HashData`, and verify credentials using `CryptographicOperations.FixedTimeEquals` to mitigate timing attacks.
- Remove plaintext password logging and adapt login handling in `Runtime/NetworkManager.cs` to log only the account and to return `LogicErrAccount` when credentials are invalid.

### Testing

- Reviewed diffs with `git diff` and searched references with `rg` to confirm all `Password` usages were updated, which succeeded.
- Attempted a build with `dotnet build TestKCPServer.sln -v minimal` but the environment lacks the .NET SDK, so the build could not be executed (`dotnet: command not found`).
- Committed the changes (`Harden login credential handling`), and validated source-level changes via `git status`/`git diff`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb8a91d108330b44f4970426a73af)