### PR TITLE
Validate packet lengths before processing

### DIFF
--- a/NetCore/Transports/ServerTransport.cs
+++ b/NetCore/Transports/ServerTransport.cs
@@ -72,16 +72,31 @@ public abstract class ServerTransport
     /// <param name="onCommand">处理数据流的回调</param>
     /// <param name="onCatch">发生异常的回调</param>
     /// <param name="onFinally">发生异常的最终处理回调</param>
-    public void OnMessageProcess(byte[] buffer, MemoryStream stream, Action<byte> onCommand, Action? onCatch = null, Action? onFinally = null)
-    { 
-        var packet = new Packet();
-        unsafe
-        {
-            // 通过指针来获取头数据，以此获取出数据本身字节长度
-            fixed (byte* src = buffer) packet._head = *((Head*)src);
-        }
+    /// <param name="messageLength">实际接收到的字节长度</param>
+    public void OnMessageProcess(byte[] buffer, MemoryStream stream, Action<byte> onCommand, Action? onCatch = null, Action? onFinally = null, int messageLength = -1)
+    {
         try
         {
+            var receivedLength = messageLength < 0 ? buffer.Length : messageLength;
+            if (receivedLength < Head.HeadLength || receivedLength > buffer.Length)
+            {
+                LogManager.Instance.Log(LogType.Warning,$"Invalid message length: receivedLength:{receivedLength} bufferLength:{buffer.Length} headLength:{Head.HeadLength}");
+                return;
+            }
+
+            var packet = new Packet();
+            unsafe
+            {
+                // 通过指针来获取头数据，以此获取出数据本身字节长度
+                fixed (byte* src = buffer) packet._head = *((Head*)src);
+            }
+
+            if (packet._head._length < 0 || packet._head._length > receivedLength - Head.HeadLength)
+            {
+                LogManager.Instance.Log(LogType.Warning,$"Invalid packet length: cmd:{packet._head._cmd} packetLength:{packet._head._length} receivedLength:{receivedLength}");
+                return;
+            }
+
             stream.Reset();
             stream.Write(buffer, Head.HeadLength, packet._head._length);
             stream.Seek(0, SeekOrigin.Begin);

--- a/Runtime/NetworkManager.cs
+++ b/Runtime/NetworkManager.cs
@@ -166,7 +166,7 @@ public class NetworkManager : AManager<NetworkManager>
                     break;
                 }
             }
-        }, _kcpServerTransport.Shutdown);
+        }, () => _kcpServerTransport.Disconnect(connectionId));
     }
 
     /// <summary>
@@ -376,7 +376,7 @@ public class NetworkManager : AManager<NetworkManager>
                     break;
                 }
             }
-        }, _tcpServerTransport.Shutdown);
+        }, _tcpServerTransport.Shutdown, messageLength: read);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Prevent a remotely-triggerable denial-of-service caused by trusting an attacker-controlled header length that could cause `MemoryStream.Write` to throw and invoke a global shutdown callback. 
- Ensure the parser checks that the received buffer contains at least the fixed header and that the header length is non-negative and no larger than the bytes actually received. 
- Reduce blast radius for parsing errors by disconnecting the offending KCP connection instead of stopping the entire KCP server.

### Description
- Added a `messageLength` parameter to `ServerTransport.OnMessageProcess` and documented it as the actual number of bytes received. 
- Validate `receivedLength` before reading the unsafe header and reject messages shorter than `Head.HeadLength` or longer than the provided buffer. 
- Validate `packet._head._length` to ensure it is non-negative and does not exceed `receivedLength - Head.HeadLength` before performing `stream.Write`. 
- In `NetworkManager`, pass the actual TCP read length to `OnMessageProcess` and change the KCP error callback to disconnect only the offending `connectionId` rather than shutting down the whole KCP server.

### Testing
- Ran `git diff --check` with no reported issues. 
- Attempted `dotnet --info` but it failed in the environment because `dotnet` is not installed, so no build/run tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5ce17a90833096a2d32d72dfa9e4)